### PR TITLE
Missing verb in the first question when creating a new project

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -48,7 +48,7 @@ async function createProject() {
     questions.push({
         type: 'input',
         name: 'name',
-        message: 'What the name of your project?',
+        message: 'What is the name of your project?',
         default: 'osbx-project'
     });
 


### PR DESCRIPTION
I just noticed when re-reading [the wiki](https://wiki.osbx.org/osbx/installation#installing-with-osbx-cli) that the question "What the name of your project?" is missing the verb.

That's a quick typo fix I guess.